### PR TITLE
Enable Javascript memory logging by default

### DIFF
--- a/extension/defaults/preferences/memchaser.js
+++ b/extension/defaults/preferences/memchaser.js
@@ -1,1 +1,2 @@
 pref("extensions.memchaser.firstrun", true);
+pref("javascript.options.mem.log", true);


### PR DESCRIPTION
Simply add the preference to the default extension preferences. That way it will be enabled with the restart of Firefox.
