### PR TITLE
Include version and build number in filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
+MemChaser
+=========
+
 [MemChaser](https://wiki.mozilla.org/QA/Automation_Services/Projects/Addons/MemChaser) is a Firefox extension which keeps track of the garbage collector activity and memory usage.
+
+How to build
+------------
+
+To build simply run `ant` and the default build script/target will be invoked:
+
+    ant
+
+You can override the build number used in the filename:
+
+    ant -Dbuild.number=1
+
+To build for release (no build version in filename):
+
+    ant -Drelease=true

--- a/build.xml
+++ b/build.xml
@@ -11,6 +11,10 @@ build.xml adapted from Shawn Wilsher's rtse
   <tstamp>
     <format property="build.number" pattern="yyyyMMddHHmm"/>
   </tstamp>
+
+  <condition property="filename" value="${ant.project.name}-${build.version}.xpi">
+    <isset property="release"/>
+  </condition>
   <property name="filename" value="${ant.project.name}-${build.version}-${build.number}.xpi"/>
 
   <target name="createxpi">


### PR DESCRIPTION
- Version is taken from `build.version` in build.properties unless specified on the command line.
- Build number is current timestamp unless specified on the command line.

To specify command line properties:

```
ant -Dbuild.version=0.1 -Dbuild.number=1
```
