### PR TITLE
Dispatch data from observe callback via setTimeout

### DIFF
--- a/extension/lib/garbage-collector.js
+++ b/extension/lib/garbage-collector.js
@@ -84,7 +84,10 @@ const reporter = EventEmitter.compose({
       duration: (RegExp.$4) ? RegExp.$4 : RegExp.$3
     }
 
-    this._emit('data', data);
+    let self = this;
+    require("timer").setTimeout(function () {
+      self._emit('data', data);
+    });
   }
 })();
 


### PR DESCRIPTION
It's not allowed from observer callbacks to directly dispatch the data. Lets do it via a call to setTimeout.
