### PR TITLE
Reduced width of widget to limit wasted space

### DIFF
--- a/extension/lib/main.js
+++ b/extension/lib/main.js
@@ -45,7 +45,7 @@ exports.main = function (options, callbacks) {
     contentURL: [self.data.url("widget/widget.html")],
     contentScriptFile: [self.data.url("widget/widget.js")],
     contentScriptWhen: "ready",
-    width: 400
+    width: 350
   });
 
   var loggerWidget = widgets.Widget({


### PR DESCRIPTION
Tested with the following, and there's ~10px left over for variance:

```
Resident: 0000MB, iGC: 000.0ms (00.0s), CC: 000.0ms (00.0s)
```
