### PR TITLE
Enhance parser for GC/CC related messages to extract all data. Fixes issue #30

### DIFF
--- a/extension/lib/config.js
+++ b/extension/lib/config.js
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+const APP_BRANCH = parseInt(/^[\d]+/.exec(require("xul-app").version)[0]);
+
+
+/**
+ * GC/CC key:value pairs we are interested in
+ */
+const GARBAGE_COLLECTOR_DATA = {
+    "10" : {
+        // CC timestamp: 1325854683540071, collected: 75 (75 waiting for GC),
+        //               suspected: 378, duration: 19 ms.
+        // GC mode: full, timestamp: 1325854678521066, duration: 32 ms.
+        "cc" : [
+          { label: "collected", regex: " ([^,]+)" },
+          { label: "duration", regex: " (\\d+)" },
+          { label: "suspected", regex: " (\\d+)" },
+        ],
+        "gc" : [
+          { label: "duration", regex: " (\\d+)" },
+          { label: "mode", regex: " (\\w+)" },
+        ]
+    },
+    "11" : {
+        // CC(T+9.6) collected: 1821 (1821 waiting for GC), suspected: 18572,
+        //           duration: 31 ms.
+        // GC(T+0.0) Type:Glob, Total:27.9, Wait:0.6, Mark:13.4, Sweep:12.6, FinObj:3.7,
+        //           FinStr:0.2, FinScr:0.5, FinShp:2.1, DisCod:0.3, DisAnl:3.0,
+        //           XPCnct:0.8, Destry:0.0, End:2.1, +Chu:16, -Chu:0, Reason:DestC
+        "cc" : [
+          { label: "collected", regex: " ([^,]+)" },
+          { label: "duration", regex: " (\\d+)" },
+          { label: "suspected", regex: " (\\d+)" },
+        ],
+        "gc" : [
+          { label: "Total", regex: "([\\d\\.]+)" },
+          { label: "Type", regex: "(\\w+)" },
+          { label: "Reason", regex: "\\s*(\\w+)" },
+        ]
+    },
+    "13" : {
+        // GC(T+0.0) TotalTime: 254.2ms, Type: global, MMU(20ms): 0%, MMU(50ms): 0%, 
+        //              Reason: MAYBEGC, +chunks: 0, -chunks: 0 mark: 160.2, 
+        //              mark-roots: 5.8, mark-other: 3.6, sweep: 92.0, sweep-obj: 7.9, 
+        //              sweep-string: 12.2, sweep-script: 1.2, sweep-shape: 6.7, 
+        //              discard-code: 6.8, discard-analysis: 46.4, xpconnect: 3.5, 
+        //              deallocate: 0.4
+        // GC(T+141.6) TotalTime: 21.4ms, Type: global, MMU(20ms): 39%, MMU(50ms): 75%,
+        //             MaxPause: 12.0, +chunks: 0, -chunks: 0
+        //             Slice 0 @ 12.0ms (Pause: 12.0, Reason: PAGE_HIDE): mark: 11.6,
+        //                               mark-roots: 1.5
+        //             Slice 2 @ 222.2ms (Pause: 7.2, Reason: INTER_SLICE_GC): mark: 1.2,
+        //                               mark-delayed: 0.1, mark-other: 1.0, sweep: 5.2,
+        //                               sweep-obj: 1.0, sweep-string: 0.1,
+        //                               sweep-script: 0.1, sweep-shape: 0.9,
+        //                               discard-code: 0.1, discard-analysis: 1.1,
+        //                               xpconnect: 0.7, deallocate: 0.1
+        //             Totals: mark: 14.9, mark-roots: 1.5, mark-delayed: 0.3,
+        //                     mark-other: 1.0, sweep: 5.2, sweep-obj: 1.0,
+        //                     sweep-string: 0.1, sweep-script: 0.1, sweep-shape: 0.9,
+        //                     discard-code: 0.1, discard-analysis: 1.1,
+        //                     xpconnect: 0.7, deallocate: 0.1
+        // CC(T+0.0) collected: 76 (76 waiting for GC), suspected: 555, duration: 16 ms.
+        //           ForgetSkippable 42 times before CC, min: 0 ms, max: 21 ms, 
+        //           avg: 1 ms, total: 50 ms, removed: 7787
+        "cc" : [
+          { label: "collected", regex: " ([^,\\n]+)" },
+          { label: "duration", regex: " (\\d+)" },
+          { label: "suspected", regex: " (\\d+)" },
+        ],
+        "gc" : [
+          { label: "MaxPause", regex: " ([\\d\\.]+)" },
+          { label: "TotalTime", regex: " ([\\d\\.]+)" },
+          { label: "Type", regex: " (\\w+)" },
+          { label: "Reason", regex: "\\s*(\\w+)" },
+        ]
+    }
+};
+
+
+exports.APP_BRANCH = APP_BRANCH;
+exports.GARBAGE_COLLECTOR_DATA = GARBAGE_COLLECTOR_DATA;

--- a/extension/lib/garbage-collector.js
+++ b/extension/lib/garbage-collector.js
@@ -4,19 +4,18 @@
 
 "use strict";
 
-Components.utils.import('resource://gre/modules/Services.jsm');
-
-
-const {Cc,Ci} = require("chrome");
-
+const {Cc, Ci} = require("chrome");
 const { EventEmitter } = require("api-utils/events");
 const prefs = require("api-utils/preferences-service");
-const self = require("self");
 const unload = require("api-utils/unload");
 
-const MEM_LOGGER_PREF = "javascript.options.mem.log";
-const MODIFIED_PREFS_PREF = "extensions." + self.id + ".modifiedPrefs";
-const GC_INCREMENTAL_PREF = "javascript.options.mem.gc_incremental"
+const config = require("config");
+
+Components.utils.import('resource://gre/modules/Services.jsm');
+
+const PREF_MEM_LOGGER = "javascript.options.mem.log";
+const PREF_MODIFIED_PREFS = "extensions." + require("self").id + ".modifiedPrefs";
+const PREF_INCREMENTAL_GC = "javascript.options.mem.gc_incremental";
 
 
 const reporter = EventEmitter.compose({
@@ -29,16 +28,29 @@ const reporter = EventEmitter.compose({
 
     // For now the logger preference has to be enabled to be able to
     // parse the GC / CC information from the console service messages
-    this._isEnabled = prefs.get(MEM_LOGGER_PREF);
+    this._isEnabled = prefs.get(PREF_MEM_LOGGER);
     if (!this._isEnabled)
       this._enable();
 
     // Determine whether incremental GC is supported in this binary
-    this._igcSupported = prefs.get(GC_INCREMENTAL_PREF)
+    this._igcSupported = prefs.get(PREF_INCREMENTAL_GC)
     if (typeof(this._igcSupported) === 'undefined')
       this._igcSupported = false;
     else
       this._igcSupported = true;
+
+    // When we have to parse console messages find the right data
+    switch (config.APP_BRANCH) {
+      case 10:
+        this._collector_data = config.GARBAGE_COLLECTOR_DATA["10"];
+        break;
+      case 11:
+      case 12:
+        this._collector_data = config.GARBAGE_COLLECTOR_DATA["11"];
+        break;
+      default:
+        this._collector_data = config.GARBAGE_COLLECTOR_DATA["13"];
+    }
 
     Services.console.registerListener(this);
   },
@@ -63,76 +75,61 @@ const reporter = EventEmitter.compose({
   },
 
   _enable: function() {
-    var modifiedPrefs = JSON.parse(prefs.get(MODIFIED_PREFS_PREF, "{}"));
-    if (!modifiedPrefs.hasOwnProperty(MEM_LOGGER_PREF)) {
-      modifiedPrefs[MEM_LOGGER_PREF] = prefs.get(MEM_LOGGER_PREF);
+    var modifiedPrefs = JSON.parse(prefs.get(PREF_MODIFIED_PREFS, "{}"));
+    if (!modifiedPrefs.hasOwnProperty(PREF_MEM_LOGGER)) {
+      modifiedPrefs[PREF_MEM_LOGGER] = prefs.get(PREF_MEM_LOGGER);
     }
-    prefs.set(MEM_LOGGER_PREF, true);
-    prefs.set(MODIFIED_PREFS_PREF, JSON.stringify(modifiedPrefs));
+    prefs.set(PREF_MEM_LOGGER, true);
+    prefs.set(PREF_MODIFIED_PREFS, JSON.stringify(modifiedPrefs));
     this._isEnabled = true;
   },
 
   /**
    * Until we have an available API to retrieve GC related information we have to
    * parse the console messages in the Error Console
-   *
-   * Firefox <11
-   * GC mode: full, timestamp: 1325854678521066, duration: 32 ms.
-   * CC timestamp: 1325854683540071, collected: 75 (75 waiting for GC),
-   *               suspected: 378, duration: 19 ms.
-   *
-   * Firefox 11 and 12
-   * GC(T+0.0) Type:Glob, Total:27.9, Wait:0.6, Mark:13.4, Sweep:12.6, FinObj:3.7,
-   *           FinStr:0.2, FinScr:0.5, FinShp:2.1, DisCod:0.3, DisAnl:3.0,
-   *           XPCnct:0.8, Destry:0.0, End:2.1, +Chu:16, -Chu:0, Reason:DestC
-   * CC(T+9.6) collected: 1821 (1821 waiting for GC), suspected: 18572,
-   *           duration: 31 ms.
-   *
-   * Firefox >13
-   * GC(T+0.0) TotalTime: 254.2ms, Type: global, MMU(20ms): 0%, MMU(50ms): 0%, 
-   *              Reason: MAYBEGC, +chunks: 0, -chunks: 0 mark: 160.2, 
-   *              mark-roots: 5.8, mark-other: 3.6, sweep: 92.0, sweep-obj: 7.9, 
-   *              sweep-string: 12.2, sweep-script: 1.2, sweep-shape: 6.7, 
-   *              discard-code: 6.8, discard-analysis: 46.4, xpconnect: 3.5, 
-   *              deallocate: 0.4
-   *
-   * CC(T+0.0) collected: 76 (76 waiting for GC), suspected: 555, duration: 16 ms.
-   *           ForgetSkippable 42 times before CC, min: 0 ms, max: 21 ms, 
-   *           avg: 1 ms, total: 50 ms, removed: 7787
    **/
-  observe: function(aMessage) {
+  observe: function Reporter_observe(aMessage) {
     var msg = aMessage.message;
 
-    // Only process messages from the garbage collector
-    if (! msg.match(/^(CC|GC).*/i))
+    var sections = /^(CC|GC)/i.exec(msg);
+    if (sections === null)
       return;
 
-    // Parse GC/CC duration from the message
-    var matches = /^(CC|GC).*(duration: ([\d\.]+)|Total:([\d\.]+)|TotalTime: ([\d\.]+))/i.exec(msg);
-    var data = { }
-      , key = matches[1].toLowerCase();
-    data[key] = {
-      timestamp: new Date(),
-    }
-    
-    switch(true){
-      case (matches[3] != null):
-        data[key]["duration"] = matches[3];
-        break;
-      case (matches[4] != null):
-        data[key]["duration"] = matches[4];
-        break;
-      case (matches[5] != null):
-        data[key]["duration"] = matches[5];
-        break;
-    }
+    var data = this.parseConsoleMessage(sections[1].toLowerCase(), msg);
 
     let self = this;
     require("timer").setTimeout(function () {
-      self._emit('data', data);
+      self._emit("data", data);
     });
+  },
+
+  /**
+   * Parse the console message for all wanted entries
+   */
+  parseConsoleMessage : function Reporter_parseConsoleMessage(aType, aMessage) {
+    /**
+     * Inline function to retrieve the value for a given key
+     */
+    function getValueFor(aKey, aRegex) {
+      var regexp = new RegExp(aKey + ":" + aRegex, "i");
+      var matches = regexp.exec(aMessage);
+
+      return matches ? matches[1] : undefined;
+    }
+
+    var data = { };
+    data[aType] = {
+      timestamp : new Date()
+    };
+
+    this._collector_data[aType].forEach(function (aEntry) {
+      data[aType][aEntry.label] = getValueFor(aEntry.label, aEntry.regex)
+    });
+
+    return data;
   }
 })();
+
 
 exports.on = reporter.on;
 exports.igcSupported = reporter.igcSupported;


### PR DESCRIPTION
This patch implements the first version of a flexible parser for GC/CC messages via the console service. We can add more data when we have to. For now the currently used one should be sufficient.

I also have started a new config module, which we can enhance with the next version.
