### PR TITLE
Fix properties in garbage collector message for Firefox 14. Fixes #92

### DIFF
--- a/extension/data/widget/widget.js
+++ b/extension/data/widget/widget.js
@@ -18,10 +18,10 @@ self.port.on("update_garbage_collector", function(data) {
     if (!data[aType])
       return;
 
-    // If MaxPause is reported we have an incremental GC
+    // Check for an incremental GC
     if (aType === "gc") {
       var label = document.getElementById("gc_label");
-      label.textContent = ("MaxPause" in data[aType]) ? "iGC: " : "GC: ";
+      label.textContent = (data[aType].isIncremental ? "iGC: " : "GC: ");
     }
 
     var duration = document.getElementById(aType + "_duration");

--- a/extension/lib/config.js
+++ b/extension/lib/config.js
@@ -78,6 +78,46 @@ const GARBAGE_COLLECTOR_DATA = {
           { label: "Type", regex: " (\\w+)" },
           { label: "Reason", regex: "\\s*(\\w+)" },
         ]
+    },
+    "14" : {
+        // GC(T+9.7) Total Time: 21.4ms, Type: global, MMU (20ms): 0%, MMU (50ms): 57%,
+        //           Reason: CC_WAITING, Nonincremental Reason: GC mode, +Chunks: 0,
+        //           -Chunks: 0
+        //           Totals: Mark: 17.0ms, Mark Roots: 2.1ms, Mark Other: 1.3ms,
+        //           Sweep: 4.1ms, Sweep Object: 0.5ms, Sweep String: 0.0ms,
+        //           Sweep Script: 0.1ms, Sweep Shape: 0.8ms, Discard Code: 0.2ms,
+        //           Discard Analysis: 0.2ms, XPConnect: 0.5ms, Deallocate: 0.1ms
+        //
+        // GC(T+73.6) Total Time: 34.2ms, Type: global, MMU (20ms): 33%, MMU (50ms): 73%,
+        //            Max Pause: 13.3ms, +Chunks: 0, -Chunks: 0
+        //              Slice: 0, Time: 13.3ms (Pause: 13.3, Reason: CC_WAITING):
+        //                Mark: 12.8ms, Mark Roots: 2.8ms
+        //              Slice: 3, Time: 337.2ms (Pause: 9.1, Reason: INTER_SLICE_GC):
+        //                Mark: 2.5ms, Mark Delayed: 0.1ms, Mark Other: 2.4ms,
+        //                Sweep: 6.2ms, Sweep Object: 0.7ms, Sweep String: 0.0ms,
+        //                Sweep Script: 0.1ms, Sweep Shape: 1.0ms, Discard Code: 0.3ms,
+        //                Discard Analysis: 0.3ms, XPConnect: 0.7ms, Deallocate: 0.0ms
+        //            Totals: Mark: 27.1ms, Mark Roots: 2.8ms, Mark Delayed: 0.2ms,
+        //            Mark Other: 2.4ms, Sweep: 6.2ms, Sweep Object: 0.7ms,
+        //            Sweep String: 0.0ms, Sweep Script: 0.1ms, Sweep Shape: 1.0ms,
+        //            Discard Code: 0.3ms, Discard Analysis: 0.3ms, XPConnect: 0.7ms,
+        //            Deallocate: 0.0ms
+        //
+        // CC(T+18.3) duration: 8ms, suspected: 116, visited: 4079 RCed and 6640 GCed,
+        //            collected: 50 RCed and 0 GCed (50 waiting for GC)
+        //            ForgetSkippable 2 times before CC, min: 0 ms, max: 1 ms,
+        //            avg: 1 ms, total: 2 ms, removed: 109
+        "cc" : [
+          { label: "collected", regex: " ([^,\\n]+)" },
+          { label: "duration", regex: " (\\d+)" },
+          { label: "suspected", regex: " (\\d+)" },
+        ],
+        "gc" : [
+          { label: "Max Pause", regex: " ([\\d\\.]+)" },
+          { label: "Total Time", regex: " ([\\d\\.]+)" },
+          { label: "Type", regex: " (\\w+)" },
+          { label: "Reason", regex: "\\s*(\\w+)" },
+        ]
     }
 };
 

--- a/extension/lib/garbage-collector.js
+++ b/extension/lib/garbage-collector.js
@@ -40,8 +40,11 @@ const reporter = EventEmitter.compose({
       case 12:
         this._collector_data = config.GARBAGE_COLLECTOR_DATA["11"];
         break;
-      default:
+      case 13:
         this._collector_data = config.GARBAGE_COLLECTOR_DATA["13"];
+        break;
+      default:
+        this._collector_data = config.GARBAGE_COLLECTOR_DATA["14"];
     }
 
     Services.console.registerListener(this);

--- a/extension/lib/main.js
+++ b/extension/lib/main.js
@@ -52,7 +52,13 @@ exports.main = function (options, callbacks) {
   // If new data from garbage collector is available update global data
   garbage_collector.on("data", function (data) {
     function getDuration(entry) {
-      return entry.duration || entry.MaxPause || entry.Total || entry.TotalTime;
+      return entry.duration ||
+             (entry.MaxPause || entry['Max Pause']) ||
+             (entry.Total || entry.TotalTime || entry['Total Time']);
+    }
+
+    function isIncremental(entry) {
+      return (entry["MaxPause"] || entry["Max Pause"]) ? true : false;
     }
 
     for (var entry in data) {
@@ -64,6 +70,9 @@ exports.main = function (options, callbacks) {
 
       var duration = getDuration(data[entry]);
       data[entry].duration = duration;
+      if (entry === "gc") {
+        data[entry].isIncremental = isIncremental(data[entry]);
+      }
 
       if (entry in gData.previous.garbage_collector) {
         var currentTime = gData.current.garbage_collector[entry].timestamp.getTime();


### PR DESCRIPTION
We really would need a better transformation table. What we have right now is really not sufficient for changes in the messages. That should be worked out for 0.3 when implementing the observer notifications. For the minor version it's fine to do it that way.
