### PR TITLE
Use postMessage for widget and panel communication instead port object (#185)

### DIFF
--- a/extension/data/panel/context.js
+++ b/extension/data/panel/context.js
@@ -3,16 +3,20 @@
 
   elements.forEach(function (element) {
     element.onclick = function () {
-      self.port.emit("command", { type: this.dataset.action});
+      self.postMessage({ type: "command", data: this.dataset.action });
     };
   });
 })();
 
 
-self.port.on("update", function (aData) {
-  let data = aData || { };
+self.on("message", function (aMessage) {
+  let { type, data } = aMessage;
+  switch (type) {
+    case "update":
 
-  var logger_status = document.querySelector("#logger_status");
-  var action = (aData.logger_active) ? "Stop " : "Start ";
-  logger_status.textContent = action + "Logging";
+      var logger_status = document.querySelector("#logger_status");
+      var action = (data.logger_active) ? "Stop " : "Start ";
+      logger_status.textContent = action + "Logging";
+      break;
+  }
 });


### PR DESCRIPTION
A fix for #185.

As you can see 
- `object.postMessage({emitMessage: aData}, "*")` is the new `object.port.emit("emitMessage", {aData})`
- `object.on("message", function ({emitMessage: aData}) { ... })` + early `return` is the new `object.port.on("emitMessage", function (aData) { ... })`

Also changed some parameter name `data` to `aData`.
