### PR TITLE
Use |.residentFast| instead of |.resident| (#192)

### DIFF
--- a/extension/lib/memory.js
+++ b/extension/lib/memory.js
@@ -46,7 +46,7 @@ const reporter = EventEmitter.compose({
     var data = {
       timestamp:  Date.now(),
       //explicit: memSrv.explicit,
-      resident: memSrv.resident
+      resident: memSrv.residentFast
     }
 
     this._emit(config.application.topic_memory_statistics, data);


### PR DESCRIPTION
Easy fix for issue #192.
