### PR TITLE
contentURL expects a string in Panel() and Widget() constructors

### DIFF
--- a/extension/lib/main.js
+++ b/extension/lib/main.js
@@ -44,7 +44,7 @@ exports.main = function (options, callbacks) {
   var contextPanel = panel.Panel({
     width: 128,
     height: 107,
-    contentURL: [self.data.url("panel/context.html")],
+    contentURL: self.data.url("panel/context.html"),
     contentScriptFile: [self.data.url("panel/context.js")],
     contentScriptWhen: "ready"
   });
@@ -87,7 +87,7 @@ exports.main = function (options, callbacks) {
     id: "memchaser-widget",
     label: "MemChaser",
     tooltip: "MemChaser",
-    contentURL: [self.data.url("widget/widget.html")],
+    contentURL: self.data.url("widget/widget.html"),
     contentScriptFile: [self.data.url("widget/widget.js")],
     contentScriptWhen: "ready",
     panel: contextPanel,


### PR DESCRIPTION
@whimboo [noted](https://github.com/mozilla/memchaser/pull/194#issuecomment-54984663) ...:

> Looks like memchaser stopped working in the 34.0 builds of Aurora. We should make some progress here to get a compatible version out.

And @tuchida [provided](https://github.com/mozilla/memchaser/pull/194#issuecomment-55098837) an easy fix, commited here.

@whimboo, Travis CI build failed ... with an unknown reason to me.
Should I add an "Update SDK to latest version" commit here too?
