### PR TITLE
Fix test_start_stop_logging for 'File not found' error (#199)

### DIFF
--- a/extension/test/test-logger.js
+++ b/extension/test/test-logger.js
@@ -44,6 +44,7 @@ exports.test_default_to_not_logging = function (test) {
   var logger = new Logger({ dir: dir });
 
   test.assert(!logger.active);
+  test.done();
 }
 
 exports.test_start_stop_logging = function (test) {
@@ -61,8 +62,7 @@ exports.test_start_stop_logging = function (test) {
   logger.active = false;
   test.assert(!logger.active);
 
-  logger._file.remove(false);
-  test.assert(!logger._file.exists(), "Clean-up; delete test file");
+  test.done();
 }
 
 exports.test_log_and_callback = function (test) {
@@ -98,7 +98,7 @@ exports.test_start_directory_change_nsIFile = function (test) {
     test.assertEqual(message[1].data.x, 60);
     test.assertEqual(message[2].data.x, 70);
   }));
-    
+
   test.waitUntilDone(2000);
 }
 


### PR DESCRIPTION
Actually the problem here is that we do not store any data when quickly starting and stopping the logger. So there is no need to remove a file at all. Instead we should really call a test.done() for some other methods too. @xabolcs would you mind to review this change?

This fixes issue #199.
