### PR TITLE
Say goodbye to EventEmitters!

### DIFF
--- a/extension/lib/config.js
+++ b/extension/lib/config.js
@@ -19,7 +19,6 @@ const PREFERENCES = {
     modified_prefs: 'extensions.' + self.id + '.modifiedPrefs',
 
     // Application preferences
-    memory_log: 'javascript.options.mem.log',
     memory_notify: 'javascript.options.mem.notify'
 }
 

--- a/extension/lib/garbage-collector.js
+++ b/extension/lib/garbage-collector.js
@@ -5,7 +5,7 @@
 "use strict";
 
 const { Cc, Ci, Cu } = require("chrome");
-const { EventEmitter } = require("sdk/deprecated/events");
+const { emit, on, off } = require("sdk/event/core");
 const prefs = require("sdk/preferences/service");
 const timers = require("sdk/timers");
 const unload = require("sdk/system/unload");
@@ -14,59 +14,16 @@ const config = require("./config");
 
 Cu.import('resource://gre/modules/Services.jsm');
 
-const reporter = EventEmitter.compose({
-  _pref_gc_notifications: null,
+const PREF_GC_NOTIFICATIONS = config.preferences.memory_notify;
 
-  constructor: function Reporter() {
-    // Report unhandled errors from listeners
-    this.on("error", console.exception.bind(console));
+var _isEnabled;
+var reporter = {
+  name: "CollectorReporter",
+  pref_gc_notifications: PREF_GC_NOTIFICATIONS
+};
 
-    // Make sure we clean-up correctly
-    unload.ensure(this, 'unload');
-
-    if (config.application.branch >= 16) {
-      this._pref_gc_notifications = config.preferences.memory_notify;
-    }
-    else {
-      this._pref_gc_notifications = config.preferences.memory_log;
-    }
-
-    // Ensure GC/CC observer and console messages preference is enabled
-    this._isEnabled = prefs.get(this._pref_gc_notifications);
-    if (!this._isEnabled)
-      this._enable();
-
-    Services.obs.addObserver(this, config.application.topic_cc_statistics, false);
-    Services.obs.addObserver(this, config.application.topic_gc_statistics, false);
-  },
-
-  get pref_gc_notifications() {
-    return this._pref_gc_notifications;
-  },
-
-  unload: function Reporter_unload() {
-    this._removeAllListeners();
-
-    Services.obs.removeObserver(this, config.application.topic_cc_statistics, false);
-    Services.obs.removeObserver(this, config.application.topic_gc_statistics, false);
-  },
-
-  _enable: function Reporter__enable() {
-    var modifiedPrefs = JSON.parse(prefs.get(config.preferences.modified_prefs,
-                                             "{}"));
-    if (!modifiedPrefs.hasOwnProperty(this._pref_gc_notifications)) {
-      modifiedPrefs[this._pref_gc_notifications] = prefs.get(this._pref_gc_notifications);
-    }
-
-    prefs.set(this._pref_gc_notifications, true);
-    prefs.set(config.preferences.modified_prefs, JSON.stringify(modifiedPrefs));
-    this._isEnabled = true;
-  },
-
-  /**
-   * Callback for GC/CC related observer notifications
-   */
-  observe: function Reporter_observe(aSubject, aTopic, aData) {
+var CollectorObserver = {
+  observe: function CollectorObserver_observe(aSubject, aTopic, aData) {
     let data = { };
     let type = aTopic;
 
@@ -80,13 +37,40 @@ const reporter = EventEmitter.compose({
     if ('timestamp' in data)
       data['timestamp'] = Math.round(data['timestamp'] / 1000);
 
-    // Once the console listener can be removed, we can emit directly
-    timers.setTimeout(function (aScope) {
-      aScope._emit(type, data);
-    }, 0, this);
+    emit(reporter, type, data);
   }
-})();
+}
 
+var _enable = function () {
+  var modifiedPrefs = JSON.parse(prefs.get(config.preferences.modified_prefs,
+                                            "{}"));
+  if (!modifiedPrefs.hasOwnProperty(PREF_GC_NOTIFICATIONS)) {
+    modifiedPrefs[PREF_GC_NOTIFICATIONS] = prefs.get(PREF_GC_NOTIFICATIONS);
+  }
+
+  prefs.set(PREF_GC_NOTIFICATIONS, true);
+  prefs.set(config.preferences.modified_prefs, JSON.stringify(modifiedPrefs));
+  _isEnabled = true;
+}
+
+var init = function () {
+  // Ensure GC/CC observer and console messages preference is enabled
+  _isEnabled = prefs.get(PREF_GC_NOTIFICATIONS);
+  if (!_isEnabled)
+    _enable();
+
+  reporter.on = on.bind(null, reporter);
+  reporter.off = off.bind(null, reporter);
+
+  Services.obs.addObserver(CollectorObserver, config.application.topic_cc_statistics, false);
+  Services.obs.addObserver(CollectorObserver, config.application.topic_gc_statistics, false);
+
+  unload.when((reason) => {
+      off(reporter);
+      Services.obs.removeObserver(CollectorObserver, config.application.topic_cc_statistics, false);
+      Services.obs.removeObserver(CollectorObserver, config.application.topic_gc_statistics, false);
+  });
+}
 
 /**
  * Trigger a Cycle Collector run
@@ -107,6 +91,8 @@ var doGlobalGC = function () {
   Cu.forceGC();
   Services.obs.notifyObservers(null, "child-gc-request", null);
 }
+
+init();
 
 
 exports.reporter = reporter;

--- a/extension/lib/main.js
+++ b/extension/lib/main.js
@@ -115,7 +115,7 @@ exports.main = function (options, callbacks) {
     }
   });
 
-  memory.reporter.on(config.application.topic_memory_statistics, function (aData) {
+  function memoryStatisticsForwarder(aData) {
     if (gData.current.memory)
       gData.previous.memory = gData.current.memory;
     gData.current.memory = aData;
@@ -125,25 +125,31 @@ exports.main = function (options, callbacks) {
     // Memory statistics aren't pretty useful yet to be logged
     // See: https://github.com/mozilla/memchaser/issues/106
     //logger.log(config.application.topic_memory_statistics, aData);
-  });
+  }
 
-  garbage_collector.reporter.on(config.application.topic_gc_statistics, function (aData) {
+  memory.reporter.on(config.application.topic_memory_statistics, memoryStatisticsForwarder);
+
+  function gcStatisticsForwarder(aData) {
     if (gData.current.gc)
       gData.previous.gc = gData.current.gc;
     gData.current.gc = aData;
 
     widget.postMessage({ type: "update_garbage_collector", data: gData });
     logger.log(config.application.topic_gc_statistics, aData);
-  });
+  }
 
-  garbage_collector.reporter.on(config.application.topic_cc_statistics, function (aData) {
+  garbage_collector.reporter.on(config.application.topic_gc_statistics, gcStatisticsForwarder);
+
+  function ccStatisticsForwarder(aData) {
     if (gData.current.cc)
       gData.previous.cc = gData.current.cc;
     gData.current.cc = aData;
 
     widget.postMessage({ type: "update_cycle_collector", data: gData });
     logger.log(config.application.topic_cc_statistics, aData);
-  });
+  }
+
+  garbage_collector.reporter.on(config.application.topic_cc_statistics, ccStatisticsForwarder);
 
   simple_prefs.on('log.directory', function (aData) {
     logger.dir = prefs.get(config.preferences.log_directory);


### PR DESCRIPTION
Fix for half of #103:
 * this fix doesn't centralize the message emitters
 * this fix migrates GC and memory reporter modules to use `event/core` SDK module

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/memchaser/217)
<!-- Reviewable:end -->
